### PR TITLE
Remove the ensure option, as monitoring_checks are purged

### DIFF
--- a/manifests/cluster.pp
+++ b/manifests/cluster.pp
@@ -30,13 +30,11 @@ define monitoring_check::cluster (
     $sla                   = undef,
     $page                  = undef,
     $team                  = undef,
-    $ensure                = undef,
     $dependencies          = undef
 ) {
   require monitoring_check::check_cluster_install
 
   monitoring_check { "${cluster}_${name}":
-    ensure              => $ensure,
     command             => "/etc/sensu/plugins/check-cluster.rb  -N ${cluster} -c ${check} ${command_add}",
     runbook             => $runbook,
     annotation          => $annotation,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -140,7 +140,6 @@ define monitoring_check (
     $needs_sudo            = false,
     $sudo_user             = 'root',
     $team                  = 'operations',
-    $ensure                = 'present',
     $dependencies          = [],
     $use_sensu             = hiera('sensu_enabled', true),
     $use_nagios            = false,
@@ -159,7 +158,6 @@ define monitoring_check (
   # https://github.com/sensu/sensu/blob/master/lib/sensu/settings.rb#L215
   validate_re($name, '^[\w\.-]+$', "Your sensu check name has special chars sensu won't like: ${name}" )
 
-  validate_re($ensure, '^(present|absent)$')
   validate_string($command)
   validate_string($runbook)
   validate_re($runbook, '^(https?://|y/)')
@@ -228,7 +226,6 @@ define monitoring_check (
 
   if str2bool($use_sensu) {
     sensu::check { $name:
-      ensure              => $ensure,
       handlers            => 'default', # Always use the default handler, it'll route things via escalation_team
       command             => $real_command,
       interval            => $interval_s,


### PR DESCRIPTION
monitoring_check has use_sensu, use_nagios, and use_consul for feature toggling. The ensure=> parameter does not follow the typical contract for 'ensure', as it is used only as a passthrough to sensu::check. It provides no functionality that the use_sensu parameter does not provide, and should be removed.