### PR TITLE
Fixup docstrings

### DIFF
--- a/spec/defines/monitoring_check_spec.rb
+++ b/spec/defines/monitoring_check_spec.rb
@@ -18,7 +18,7 @@ describe 'monitoring_check' do
     let(:params) { {:command => 'bar', :runbook => 'http://gronk', :page => true} }
       it do
         expect {
-          should compile
+          should contain_sensu__check('examplecheck')
         }.to raise_error(Puppet::Error, /No sensu_handlers::teams/)
       end
   end


### PR DESCRIPTION
- Reorganizes the docstrings and options. Matches docstring ordering to option ordering.

- Small fixups to docstring content.

- Adds a docstring for timeout that was missing.

- Remove unused nagios, nagios_custom, and aggregate options.