### PR TITLE
Added sudo_isnt_ready wrapper to make it safe to remove checks that use sudo

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -4,7 +4,11 @@ fixtures:
     sudo:
         repo: 'git://github.com/bobtfish/puppet-sudo.git'
         ref: 530bb59a8d593bf664868dccd0ca2e84e8ae50f9
-    sensu: 'git://github.com/sensu/sensu-puppet.git'
-    apt: "git://github.com/bobtfish/puppetlabs-apt.git"
+    sensu:
+        repo: 'git://github.com/sensu/sensu-puppet.git'
+        ref: 1.8.0
+    apt:
+        repo: "git://github.com/puppetlabs/puppetlabs-apt.git"
+        ref: 1.8.0
   symlinks:
     monitoring_check: "#{source_dir}"

--- a/files/sudo_isnt_ready
+++ b/files/sudo_isnt_ready
@@ -1,0 +1,15 @@
+#!/bin/bash
+#
+# Returns 0 if sudo is NOT ready for a particular command.
+# Useful to detect if the sudo rules are not in place yet.
+#
+# This allows sensu to run a command and still return "OK"
+# because puppet may not have put in the sudo rules yet.
+# (Or when sensu removes sudo rules when removing a check)
+if sudo -n -l $1 >/dev/null 2>&1; then
+  exit 1
+else
+  echo "Sudo rules NOT are in place to run $1"
+  echo "This is OK if the check has been recent removed or added"
+  exit 0
+fi

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -192,7 +192,7 @@ define monitoring_check (
 
   if str2bool($needs_sudo) {
     validate_re($command, '^/.*', "Your command, ${command}, must use a full path if you are going to use sudo")
-    $real_command = "sudo -H -u ${sudo_user} -- ${command}"
+    $real_command = "sudo_isnt_ready || sudo -n -H -u ${sudo_user} -- ${command}"
     $cmd = regsubst($command, '^(\S+).*','\1') # Strip the options off, leaving just the check script
     if str2bool($use_sensu) {
       sudo::conf { "sensu_${title}":

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -59,4 +59,12 @@ class monitoring_check::params (
     source => 'puppet:///modules/monitoring_check/send-test-sensu-alert',
   }
 
+  file { "${bin_path}/sudo_isnt_ready":
+    ensure => 'file',
+    mode   => '0555',
+    owner  => 'root',
+    group  => 'root',
+    source => 'puppet:///modules/monitoring_check/sudo_isnt_ready',
+  }
+
 }

--- a/spec/classes/params_spec.rb
+++ b/spec/classes/params_spec.rb
@@ -6,7 +6,7 @@ describe 'monitoring_check::params' do
     it { should compile }
     it { should_not contain_file('/etc/facter/facts.d/override_sensu_checks_to.txt') }
     it { should contain_file('/usr/bin/send-test-sensu-alert') }
-    it { should have_file_resource_count(2)}
+    it { should have_file_resource_count(3)}
   end
   
   context "When the override_sensu_checks_to fact is present" do
@@ -17,7 +17,6 @@ describe 'monitoring_check::params' do
   context "When given a differnet path for binaries" do
     let(:params) {{ :bin_path => '/special_bin' }}
     it { should contain_file('/special_bin/send-test-sensu-alert') }
-    it { should have_file_resource_count(2)}
   end
 
 end

--- a/spec/defines/monitoring_check_spec.rb
+++ b/spec/defines/monitoring_check_spec.rb
@@ -174,7 +174,7 @@ describe 'monitoring_check' do
       let(:params) { {:command => '/bin/bar --foo --baz', :runbook => 'http://gronk', :needs_sudo => true, :sudo_user => 'fred'} }
       it do
         should contain_sensu__check('examplecheck') \
-          .with_command('sudo -H -u fred -- /bin/bar --foo --baz')
+          .with_command('sudo_isnt_ready || sudo -n -H -u fred -- /bin/bar --foo --baz')
         should contain_sudo__conf("sensu_examplecheck") \
           .with_content("sensu       ALL=(fred) NOPASSWD: /bin/bar\nDefaults!/bin/bar !requiretty")
       end


### PR DESCRIPTION
We have this problem where when puppet *removes* checks, the sudo rules are removed first, and the sensu-client isn't restart till late in the puppet run.

This leaves a lot of opportunity for spurious alerts, because the lack of sudo gives a warning (return 1)

This change adds a wrapper that returns 0 when the sudo rules are not yet in place.

This could give a false sense of "working" if sudo isn't setup, but with puppet, this should never really happen, as these are not setup by hand.