### PR TITLE
fix tests the quick way

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -5,6 +5,8 @@ fixtures:
         repo: 'git://github.com/bobtfish/puppet-sudo.git'
         ref: 530bb59a8d593bf664868dccd0ca2e84e8ae50f9
     sensu: 'git://github.com/sensu/sensu-puppet.git'
-    apt: "git://github.com/bobtfish/puppetlabs-apt.git"
+    apt:
+        repo: 'git://github.com/somic/puppetlabs-apt.git'
+        ref: ee51cf6929e1c51857ae43e720a32145df780d70
   symlinks:
     monitoring_check: "#{source_dir}"


### PR DESCRIPTION
This fixes yelp/puppet-monitoring_check tests the quick way.

I will create an issue to fix them the right way later - the failure is coming from apt:key and I don't feel like doing that now, that area needs to be cleaned up anyway.

Here is a link to the actual change that fixes these tests:
https://github.com/somic/puppetlabs-apt/commit/ee51cf6929e1c51857ae43e720a32145df780d70