### PR TITLE
Make the teams.json file depend on the sensu package existing

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -36,6 +36,7 @@ class monitoring_check::params (
       owner   => 'sensu',
       group   => 'sensu',
       mode    => '0444',
+      require => Package['sensu'],
       content => inline_template('<%= require "json"; JSON.generate @team_data_hash %>'),
     }
   }

--- a/spec/classes/params_spec.rb
+++ b/spec/classes/params_spec.rb
@@ -2,6 +2,9 @@ require 'spec_helper'
 
 describe 'monitoring_check::params' do
 
+  # Assume sensu is being installed to satisfy 'require=>' lines
+  let(:pre_condition) { 'package { "sensu": }' }
+
   context "by default" do
     it { should compile }
     it { should_not contain_file('/etc/facter/facts.d/override_sensu_checks_to.txt') }


### PR DESCRIPTION
primary: @mrtyler 

The teams.json file is owned by the sensu user and exists in the /etc/sensu dir. Both of these are created by the sensu package.

This makes that requirement explicit so puppet can converge better. Internal ticket PAASTA-648.