### PR TITLE
reuse TinyRedis::Mutex, make it return some data about the run

### DIFF
--- a/files/tiny_redis.rb
+++ b/files/tiny_redis.rb
@@ -33,10 +33,13 @@ module TinyRedis
         begin
           expire interval
           yield
+          nil
         rescue => e
           expire
           raise e
         end
+      else
+        redis.pttl(key).to_f/1000
       end
     end
 


### PR DESCRIPTION
reuse TinyRedis::Mutex in check-cluster

make `#run_with_lock_or_skip` return something useful, which is:

- `nil` in case of successful lock+run
- `pttl / 1000` - seconds til lock expires