### PR TITLE
Add option to not use handlers for a monitoring check

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,6 +13,9 @@
 # Should be of the form: y/my_runbook_name (preferred), or
 # http://...some.uri. This is required.
 #
+# [*handle*]
+# Boolean to send this check to handlers. Defaults to true
+#
 # [*needs_sudo*]
 # Boolean for if to run this check with sudo. Defaults to false
 #
@@ -121,6 +124,7 @@
 define monitoring_check (
   $command,
   $runbook,
+  $handle                = true,
   $needs_sudo            = false,
   $sudo_user             = 'root',
   $check_every           = '1m',
@@ -160,6 +164,7 @@ define monitoring_check (
   $team_names = join(keys($team_data), '|')
   validate_re($team, "^(${team_names})$")
   validate_bool($ticket)
+  validate_bool($handle)
 
   validate_hash($sensu_custom)
 
@@ -213,6 +218,7 @@ define monitoring_check (
   if str2bool($use_sensu) {
     sensu::check { $name:
       handlers            => 'default', # Always use the default handler, it'll route things via escalation_team
+      handle              => $handle,
       command             => $real_command,
       interval            => $interval_s,
       timeout             => $timeout_s,


### PR DESCRIPTION
Some checks should never alert at all, since the alerting is being done by a cluster check of many hosts. In this case, it would be nice to have the check not spawn a handler at all.

This change just creates a new, optional parameter of "handle", which is passed along to the sensu::check that is created.