### PR TITLE
To spawn no handers, send an empty array in the "handlers" param

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -166,6 +166,12 @@ define monitoring_check (
   validate_bool($ticket)
   validate_bool($handle)
 
+  if $handle {
+    $handlers = ['default'] # Use the default handler, it'll route things via escalation_team
+  } else {
+    $handlers = undef
+  }
+
   validate_hash($sensu_custom)
 
   $interval_s = human_time_to_seconds($check_every)
@@ -217,7 +223,7 @@ define monitoring_check (
 
   if str2bool($use_sensu) {
     sensu::check { $name:
-      handlers            => 'default', # Always use the default handler, it'll route things via escalation_team
+      handlers            => $handlers,
       handle              => $handle,
       command             => $real_command,
       interval            => $interval_s,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -14,7 +14,7 @@
 # http://...some.uri. This is required.
 #
 # [*handle*]
-# Boolean to send this check to handlers. Defaults to true
+# Boolean to send this check to handlers. Defaults to undef
 #
 # [*needs_sudo*]
 # Boolean for if to run this check with sudo. Defaults to false

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -124,7 +124,7 @@
 define monitoring_check (
   $command,
   $runbook,
-  $handle                = true,
+  $handle                = undef,
   $needs_sudo            = false,
   $sudo_user             = 'root',
   $check_every           = '1m',
@@ -166,9 +166,8 @@ define monitoring_check (
   validate_bool($ticket)
   validate_bool($handle)
 
-  if $handle {
-    $handlers = ['default'] # Use the default handler, it'll route things via escalation_team
-  } else {
+  $handlers = ['default'] # Use the default handler, it'll route things via escalation_team
+  if $handle == false {
     $handlers = undef
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -164,7 +164,6 @@ define monitoring_check (
   $team_names = join(keys($team_data), '|')
   validate_re($team, "^(${team_names})$")
   validate_bool($ticket)
-  validate_bool($handle)
 
   $handlers = ['default'] # Use the default handler, it'll route things via escalation_team
   if $handle == false {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,7 +15,8 @@
 #
 # [*handlers*]
 # An array of handlers to use for this check. Set to [] if this check should
-# spawn no handlers. Defaults to ['default'].
+# spawn no handlers. Defaults to ['default'], which uses standard Yelp
+# sensu_handlers that are 'team'-aware.
 #
 # [*needs_sudo*]
 # Boolean for if to run this check with sudo. Defaults to false
@@ -125,7 +126,7 @@
 define monitoring_check (
   $command,
   $runbook,
-  $handlers              = ['default'], # Use the default handler, it'll route things via escalation_team
+  $handlers              = ['default'],
   $needs_sudo            = false,
   $sudo_user             = 'root',
   $check_every           = '1m',

--- a/spec/defines/monitoring_check_spec.rb
+++ b/spec/defines/monitoring_check_spec.rb
@@ -51,6 +51,13 @@ describe 'monitoring_check' do
       it { should contain_file('/etc/sensu/team_data.json').with_content(/operations/) }
     end
 
+    context "no handlers" do
+      let(:params) { {:command => 'bar', :runbook => 'http://gronk', :handlers => []} }
+      it do
+        should contain_sensu__check('examplecheck').with_handlers([])
+      end
+    end
+
     context "bad runbook (not a uri)" do
       let(:params) { {:command => 'bar', :runbook => 'gronk'} }
       it do


### PR DESCRIPTION
We were having an issue using both the parameters "handle" and "handlers" in our Sensu check. Sensu complained that using both parameters could cause one to overwrite the other.

We still want a way to spawn no handlers for some checks. To do that now, we will pass in an empty array to the "handlers" parameter.