### PR TITLE
suppress most notifications from server-side placeholder

### DIFF
--- a/files/check_server_side.rb
+++ b/files/check_server_side.rb
@@ -43,8 +43,11 @@ class CheckServerSide < Sensu::Plugin::Check::CLI
       # execute its command and explicitly send the result of new check
       # to local redis-client process
       @new_check = { 'executed' => Time.now.to_i }.merge(check)
-      new_check['command'] = new_check.delete('actual_command')
-      new_check['name'] = new_check.delete('actual_name')
+
+      %w( command name page ticket notification_email ).each { |field|
+        new_check[field] = new_check.delete("actual_#{field}")
+      }
+
       new_check['output'] = `( #{new_check['command']} ) 2>&1`.strip
       new_check['status'] = $?.exitstatus
       new_check['issued'] = Time.now.to_i

--- a/manifests/server_side.pp
+++ b/manifests/server_side.pp
@@ -70,9 +70,12 @@ define monitoring_check::server_side (
   include monitoring_check::server_side::install
 
   $custom_server_side = {
-    actual_command => $command,
-    actual_name    => pick($event_name, $title),
-    source         => $source,
+    actual_command            => $command,
+    actual_name               => pick($event_name, $title),
+    source                    => $source,
+    actual_page               => $page,
+    actual_ticket             => $ticket,
+    actual_notification_email => $notification_email,
   }
 
   $new_title = "server_side_placeholder_for_${title}"
@@ -88,10 +91,7 @@ define monitoring_check::server_side (
     alert_after           => $alert_after,
     realert_every         => $realert_every,
     team                  => $team,
-    page                  => $page,
     irc_channels          => $irc_channels,
-    notification_email    => $notification_email,
-    ticket                => $ticket,
     project               => $project,
     tip                   => $tip,
     sla                   => $sla,

--- a/spec/defines/server_side_spec.rb
+++ b/spec/defines/server_side_spec.rb
@@ -23,34 +23,42 @@ describe 'monitoring_check::server_side' do
   context 'by default' do
     let(:params) {{
       :command => 'foo', :runbook => 'y/bar', :source => 'baz',
-      :team => 'qux',
+      :team => 'qux', :page => true
     }}
 
     it {
       should contain_class('monitoring_check::server_side::install')
       should contain_monitoring_check('server_side_placeholder_for_example1') \
                .with_command(/check_server_side.rb/) \
-               .with_sensu_custom({
+               .with_page(false) \
+               .with_sensu_custom(
                  'actual_command' => 'foo',
                  'actual_name'    => 'example1',
-                 'source'         => 'baz'
-               })
+                 'source'         => 'baz',
+                 'actual_page'    => true,
+                 'actual_ticket'  => false,
+                 'actual_notification_email' => 'undef',
+               )
     }
   end
 
   context 'with event_name' do
     let(:params) {{
       :command => 'foo', :runbook => 'y/bar', :source => 'baz',
-      :team => 'qux', :event_name => 'hello_world'
+      :team => 'qux', :event_name => 'hello_world', :ticket => true
     }}
 
     it {
       should contain_monitoring_check('server_side_placeholder_for_example1') \
-        .with_sensu_custom({
+        .with_ticket(false) \
+        .with_sensu_custom(
           'actual_command' => 'foo',
           'actual_name'    => 'hello_world',
-          'source'         => 'baz'
-        })
+          'source'         => 'baz',
+          'actual_page'    => false,
+          'actual_ticket'  => true,
+          'actual_notification_email' => 'undef'
+        )
     }
   end
 


### PR DESCRIPTION
Placeholders for server-side checks are not meant to notify humans in any significant way. This makes it so.

From my observations, placeholders notify only during some transient event - being paged by a placeholder (vs. an actual check) is meaningless and not actionable.

For tracking and potentially more context, this is OPS-7116 internally.