### PR TITLE
Debug help

### DIFF
--- a/files/check-cluster.rb
+++ b/files/check-cluster.rb
@@ -60,7 +60,7 @@ class CheckCluster < Sensu::Plugin::Check::CLI
       status, output = check_aggregate(aggregator.summary(target_interval))
       logger.puts output
       send_payload EXIT_CODES[status], output
-      ok "Check executed successfully (#{status}: #{output})"
+      ok "Cluster check successfully executed, with output: (#{status}: #{output})"
       return
     end
 

--- a/manifests/cluster.pp
+++ b/manifests/cluster.pp
@@ -36,8 +36,8 @@ define monitoring_check::cluster (
   require monitoring_check::params
   $cluster = $monitoring_check::params::cluster_name
 
-  monitoring_check { "${cluster}_${name}":
-    command             => "/etc/sensu/plugins/check-cluster.rb  -N ${cluster} -c ${check} ${command_add}",
+  monitoring_check { "${cluster}_${name}_initializer":
+    command             => "/etc/sensu/plugins/check-cluster.rb  --cluster-name ${cluster} --check ${check} ${command_add}",
     runbook             => $runbook,
     check_every         => $check_every,
     alert_after         => $alert_after,

--- a/manifests/cluster.pp
+++ b/manifests/cluster.pp
@@ -36,7 +36,7 @@ define monitoring_check::cluster (
   require monitoring_check::params
   $cluster = $monitoring_check::params::cluster_name
 
-  monitoring_check { "${cluster}_${name}_initializer":
+  monitoring_check { "${cluster}_${name}":
     command             => "/etc/sensu/plugins/check-cluster.rb  --cluster-name ${cluster} --check ${check} ${command_add}",
     runbook             => $runbook,
     check_every         => $check_every,

--- a/spec/unit/check_cluster_spec.rb
+++ b/spec/unit/check_cluster_spec.rb
@@ -58,7 +58,7 @@ describe CheckCluster do
   context "status" do
     context "should be OK" do
       it "when all is good" do
-        expect_status :ok, /Check executed successfully/
+        expect_status :ok, /Cluster check successfully executed/
         expect_payload :ok, /0%/
         check.run
       end
@@ -136,7 +136,7 @@ describe CheckCluster do
   # implementation details
   it "should run within a lock" do
     expect(redis).to receive(:setnx).and_return(1)
-    expect_status :ok, /Check executed successfully/
+    expect_status :ok, /Cluster check successfully executed/
     expect_payload :ok, /0%/
     check.run
   end


### PR DESCRIPTION
Adding verbose, dryrun flag to aid in debugging, and using more clear output messages to hopefully make it clear that an 'OK' status for this check means the checking the cluster was successful, not necessarily that the output of the cluster check was 'OK'