### PR TITLE
Removing comments on runbook, tip passthru

### DIFF
--- a/manifests/cluster.pp
+++ b/manifests/cluster.pp
@@ -14,10 +14,10 @@
 #
 #
 define monitoring_check::cluster (
+    $runbook,
     $check                 = $name,
     $command_add           = '',
-    $runbook               = '-', # these are special: if '-', value will
-    $tip                   = '-', # be taken from target check
+    $tip                   = undef,
     $check_every           = undef,
     $alert_after           = undef,
     $realert_every         = undef,


### PR DESCRIPTION
The machinery for passing through these fields no longer exists, as we can't
depend on having the individual check to pull this information from. Removing
these comments, and making runbook mandatory, for clarity.