### PR TITLE
Default interval

### DIFF
--- a/files/check-cluster.rb
+++ b/files/check-cluster.rb
@@ -71,17 +71,17 @@ class CheckCluster < Sensu::Plugin::Check::CLI
 
     lock_key = "lock:#{config[:cluster_name]}:#{config[:check]}"
     interval = cluster_check[:interval]
-    target_interval = cluster_check[:target_interval] || cluster_check[:interval]
+    staleness_interval = cluster_check[:staleness_interval] || cluster_check[:interval]
 
     if config[:dryrun]
-      status, output = check_aggregate(aggregator.summary(target_interval))
+      status, output = check_aggregate(aggregator.summary(staleness_interval))
       ok "Dry run cluster check successfully executed, with output: (#{status}: #{output})"
       return
     end
 
     mutex = TinyRedis::Mutex.new(redis, lock_key, interval, logger)
     mutex.run_with_lock_or_skip do
-      status, output = check_aggregate(aggregator.summary(target_interval))
+      status, output = check_aggregate(aggregator.summary(staleness_interval))
       logger.info output
       send_payload EXIT_CODES[status], output
       ok "Cluster check successfully executed, with output: (#{status}: #{output})"

--- a/spec/unit/check_cluster_spec.rb
+++ b/spec/unit/check_cluster_spec.rb
@@ -13,7 +13,7 @@ describe CheckCluster do
     { :checks => {
         :test_cluster_test_check => {
           :interval => 300,
-          :target_interval => 300 } } }
+          :staleness_interval => '12h' } } }
   end
 
   let(:redis)  do


### PR DESCRIPTION
This PR changes the old target_interval into staleness_interval. I think this new name makes its purpose more clear.

It also adds this as a param to monitoring_check::cluster. Before, target_interval was part of the sensu_custom hash. By making it a parameter in itself, we can cleanly give it a default value.  Right now, it defaults to 12 hours, but that value is open to discussion.

In the cluster check, we look at the latest result from each individual check. In this latest result, we can see if the check passed or failed.  What staleness_interval allows us to do, is to ensure that this latest check result was created within a reasonable timeframe. For example, if a host runs a check, gives a result of 'OK', and then the box is abducted by aliens, Sensu would still have the latest result as 'OK' for that host.  By using a staleness_interval, we can catch issues like this (well, we'd probably catch that from keepalive checks, but this ensures the cluster check treats down hosts as failures).

Before, this 'staleness_interval' would default to the check interval of the cluster check. That value defaults to 1m. That value was too short, as many individual checks occur on intervals longer than 1m, causing us to discard the latest values of individual checks that were still 'fresh'