### PR TITLE
If the lock expires sooner than rtt to redis server, return ok

### DIFF
--- a/files/check-cluster.rb
+++ b/files/check-cluster.rb
@@ -93,6 +93,11 @@ class CheckCluster < Sensu::Plugin::Check::CLI
       return
     end
 
+    if ttl.nil?
+      ok "Cluster check did not execute, lock expired sooner than round-trip time to redis server"
+      return
+    end
+
     critical "Cluster check did not execute, ttl: #{ttl.inspect}"
   rescue RuntimeError => e
     critical "#{e.message} (#{e.class}): #{e.backtrace.inspect}"

--- a/spec/unit/check_cluster_spec.rb
+++ b/spec/unit/check_cluster_spec.rb
@@ -76,6 +76,13 @@ describe CheckCluster do
         expect_status :ok, /did not execute/
         check.run
       end
+
+      it "when lock expired before " do
+        redis.stub(:setnx).and_return 0
+        redis.stub(:pttl).and_return nil
+        expect_status :ok, /did not execute/
+        check.run
+      end
     end
 
     context "should be CRITICAL" do


### PR DESCRIPTION
Implementing another check on the ttl that Maksym suggested in his comment on commit f9ae6abc6ac4ee5d1284863e3029ed6c96b258a2