### PR TITLE
Omit check results with same name as cluster_name FIXES #65

### DIFF
--- a/files/check-cluster.rb
+++ b/files/check-cluster.rb
@@ -113,7 +113,7 @@ private
   end
 
   def aggregator
-    RedisCheckAggregate.new(redis, config[:check], logger)
+    RedisCheckAggregate.new(redis, config[:check], logger, config[:cluster_name])
   end
 
   def check_sensu_version
@@ -184,10 +184,11 @@ end
 class RedisCheckAggregate
   attr_accessor :logger
 
-  def initialize(redis, check, logger)
+  def initialize(redis, check, logger, cluster_name)
     @check  = check
     @redis  = redis
     @logger = logger
+    @cluster_name = cluster_name
   end
 
   def summary(interval)
@@ -231,5 +232,6 @@ class RedisCheckAggregate
   def find_servers
     # TODO: reimplement using @redis.scan for webscale
     @servers ||= @redis.keys("result:*:#@check").map {|key| key.split(':')[1]}
+    @servers.reject {|s| s == @cluster_name }
   end
 end


### PR DESCRIPTION
This updates the RedisAggregateCheck class to ensure that we don't
return the name of the cluster check when we query redis. This way, if
we have a failure, the cluster check should clear itself up