### PR TITLE
Minimum nodes

### DIFF
--- a/files/check-cluster.rb
+++ b/files/check-cluster.rb
@@ -31,7 +31,8 @@ class CheckCluster < Sensu::Plugin::Check::CLI
     :short => "-m MIN",
     :long => "--minimum-nodes MIN",
     :description => "The minimum number of nodes that should be available",
-    :proc => proc {|a| a.to_i }
+    :proc => proc {|a| a.to_i },
+    :default => 0
 
   option :check,
     :short => "-c CHECK",
@@ -157,15 +158,11 @@ private
     message << " #{ok_pct}% OK, #{config[:critical]}% threshold"
     message << "\nStale hosts: #{stale.map{|host| host.split('.').first}.sort[0..10].join ','}" unless stale.empty?
     message << "\nFailing hosts: #{failing.map{|host| host.split('.').first}.sort[0..10].join ','}" unless failing.empty?
+    message << "\nMinimum number of hosts required is #{config[:min_nodes]} and only #{ok} found" if ok < config[:min_nodes]
 
-    if config[:min_nodes] <= 0
-      state = ok_pct >= config[:critical] ? 'OK' : 'CRITICAL'
-      return state, message
-    else
-      message << "\nMinimum number of hosts required in cluster is #{config[:min_nodes]} and only #{ok} found"
-      state = ok >= config[:min_nodes] ? 'OK' : 'CRITICAL'
-      return state, message
-    end
+    state = ok_pct >= config[:critical] ? 'OK' : 'CRITICAL'
+    state = ok >= config[:min_nodes] ? 'OK' : 'CRITICAL'
+    return state, message
   end
 
   def sensu_settings

--- a/files/check-cluster.rb
+++ b/files/check-cluster.rb
@@ -161,7 +161,7 @@ private
     message << "\nMinimum number of hosts required is #{config[:min_nodes]} and only #{ok} found" if ok < config[:min_nodes]
 
     state = ok_pct >= config[:critical] ? 'OK' : 'CRITICAL'
-    state = ok >= config[:min_nodes] ? 'OK' : 'CRITICAL'
+    state = ok >= config[:min_nodes] ? state : 'CRITICAL'
     return state, message
   end
 

--- a/spec/unit/check_cluster_spec.rb
+++ b/spec/unit/check_cluster_spec.rb
@@ -6,7 +6,8 @@ describe CheckCluster do
     { :check        => :test_check,
       :cluster_name => :test_cluster,
       :warning      => 30,
-      :critical     => 50 }
+      :critical     => 50,
+      :min_nodes    => 0 }
   end
 
   let(:sensu_settings) do

--- a/spec/unit/check_cluster_spec.rb
+++ b/spec/unit/check_cluster_spec.rb
@@ -127,6 +127,16 @@ describe CheckCluster do
         end
       end
     end
+
+    context "should be CRITICAL" do
+      let(:config) { super().merge(:min_nodes => 10) }
+      it "when minimum nodes not met" do
+        check.send(:check_aggregate, :ok => 5, :total => 5, :silenced => 0, :failing => [], :stale => []) do |status, message|
+          expect(status).to be(2)
+          expect(message).to match(/minimum/)
+        end
+      end
+    end
   end
 
   # implementation details


### PR DESCRIPTION
Adds an option to specify a minimum number of nodes that should be in the cluster in order to pass OK the check