### PR TITLE
Adding arbitrary tags (FIXED #71)

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -124,6 +124,10 @@
 # Should not be tied to a host that generated
 # this event because it can come from any host where this check is deployed.
 #
+# [*tags*]
+# An array of arbitrary tags that can be used in handlers for different metadata needs
+# such as labels in JIRA handlers. This is optional and is empty by default
+#
 # This, by default allows you to set the $::override_sensu_checks_to fact
 # in /etc/facter/facts.d to stop checks on a single machine from alerting via the
 # normal mechanism. Setting this to false will stop this mechanism from applying
@@ -154,6 +158,7 @@ define monitoring_check (
   $high_flap_threshold   = undef,
   $source                = undef,
   $can_override          = true,
+  $tags                  = [],
 ) {
 
   include monitoring_check::params
@@ -220,18 +225,19 @@ define monitoring_check (
 
 
   $base_dict = {
-    alert_after           => $alert_after_s,
-    realert_every         => $realert_every,
-    runbook               => $runbook,
-    sla                   => $sla,
-    team                  => $team,
-    irc_channels          => $irc_channel_array,
-    notification_email    => $notification_email,
-    ticket                => $ticket,
-    project               => $project,
-    page                  => str2bool($page),
-    tip                   => $tip,
-    habitat               => $::habitat,
+    alert_after        => $alert_after_s,
+    realert_every      => $realert_every,
+    runbook            => $runbook,
+    sla                => $sla,
+    team               => $team,
+    irc_channels       => $irc_channel_array,
+    notification_email => $notification_email,
+    ticket             => $ticket,
+    project            => $project,
+    page               => str2bool($page),
+    tip                => $tip,
+    habitat            => $::habitat,
+    tags               => $tags,
   }
   if $source != undef {
     $base_with_source = merge($base_dict, {

--- a/spec/defines/monitoring_check_spec.rb
+++ b/spec/defines/monitoring_check_spec.rb
@@ -51,6 +51,7 @@ describe 'monitoring_check' do
             "page"               => true,
             "tip"                => false,
             "habitat"            => "somehabitat",
+            "tags"               => [],
           })
       end
       it { should contain_file('/etc/sensu/team_data.json').with_content(/other/) }
@@ -86,6 +87,7 @@ describe 'monitoring_check' do
         "team"               => "other",
         "notification_email" => "undef",
         "habitat"            => "somehabitat",
+        "tags"               => [],
       })
       }
     end
@@ -117,6 +119,7 @@ describe 'monitoring_check' do
           "team"               => "operations",
           "notification_email" => "undef",
           "habitat"            => "somehabitat",
+          "tags"               => [],
         }
       )}
     end
@@ -136,6 +139,7 @@ describe 'monitoring_check' do
         "team"               => "overridden",
         "notification_email" => "undef",
         "habitat"            => "somehabitat",
+        "tags"               => [],
         }
       )}
     end
@@ -155,6 +159,7 @@ describe 'monitoring_check' do
           "team"               => "operations",
           "notification_email" => "undef",
           "habitat"            => "somehabitat",
+          "tags"               => [],
         }
       )}
     end
@@ -174,6 +179,7 @@ describe 'monitoring_check' do
           "team"               => "operations",
           "notification_email" => "undef",
           "habitat"            => "somehabitat",
+          "tags"               => [],
         }
       )}
     end
@@ -223,6 +229,7 @@ describe 'monitoring_check' do
         "team"               => "noop",
         "notification_email" => "custom@override",
         "habitat"            => "somehabitat",
+        "tags"               => [],
         }
       )}
     end
@@ -242,6 +249,7 @@ describe 'monitoring_check' do
         "team"               => "operations",
         "notification_email" => "undef",
         "habitat"            => "somehabitat",
+        "tags"               => [],
         }
       )}
     end
@@ -261,7 +269,28 @@ describe 'monitoring_check' do
         "team"               => "operations",
         "notification_email" => "undef",
         "habitat"            => "somehabitat",
-        "source"           => "mysource"
+        "source"             => "mysource",
+        "tags"               => [],
+        }
+      )}
+    end
+    context "with tags" do
+      let(:facts) { { :habitat => "somehabitat", :lsbdistid => 'Ubuntu', :osfamily => 'Debian', :lsbdistcodename => 'lucid', :operatingsystem => 'Ubuntu', :ipaddress => '127.0.0.1', :puppetversion => '3.6.2' } }
+      let(:params) { {:command => 'bar', :runbook => 'http://gronk', :tags => ['first_tag', 'second_tag'] } }
+      it { should contain_sensu__check('examplecheck').with_custom({
+        "runbook"            => "http://gronk",
+        "ticket"             => false,
+        "irc_channels"       => :undef,
+        "tip"                => false,
+        "project"            => false,
+        "alert_after"        => "0",
+        "page"               => false,
+        "realert_every"      => "-1",
+        "sla"                => "No SLA defined.",
+        "team"               => "operations",
+        "notification_email" => "undef",
+        "habitat"            => "somehabitat",
+        "tags"               => ['first_tag','second_tag'],
         }
       )}
     end


### PR DESCRIPTION
This is the initial start of a bigger set of changes across the infra.

Adding these tags won't make much difference to the sensu checks themselves, it'll just add a new JSON field which is an empty array.

This will be much more useful when handlers are adapted to deal with them.