### PR TITLE
make source param work with newer sensu-puppet

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -6,7 +6,7 @@ fixtures:
         ref: 530bb59a8d593bf664868dccd0ca2e84e8ae50f9
     sensu:
         repo: 'git://github.com/sensu/sensu-puppet.git'
-        ref: 288de5099814645afce643013b0951d3782ef328
+        ref: 9ba0abf38f1a0971bcd044b1bd51b58ec95783d9
     apt:
         repo: 'git://github.com/puppetlabs/puppetlabs-apt.git'
         ref: 2.1.0

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -239,20 +239,13 @@ define monitoring_check (
     habitat            => $::habitat,
     tags               => $tags,
   }
-  if $source != undef {
-    $base_with_source = merge($base_dict, {
-      source => $source
-    })
-  } else {
-    $base_with_source = $base_dict
-  }
   if getvar('::override_sensu_checks_to') and $can_override {
-    $with_override = merge($base_with_source, {
+    $with_override = merge($base_dict, {
       'team'             => 'noop',
       notification_email => $::override_sensu_checks_to,
     })
   } else {
-    $with_override = $base_with_source
+    $with_override = $base_dict
   }
   $custom = merge($with_override, $sensu_custom)
 
@@ -266,6 +259,7 @@ define monitoring_check (
       high_flap_threshold => $low_flap_threshold,
       dependencies        => any2array($dependencies),
       custom              => $custom,
+      source              => $source,
     }
   }
 }

--- a/manifests/server_side.pp
+++ b/manifests/server_side.pp
@@ -74,7 +74,6 @@ define monitoring_check::server_side (
     actual_command  => $command,
     actual_name     => pick($event_name, $title),
     actual_handlers => $handlers,
-    source          => $source,
   }
 
   $new_title = "server_side_placeholder_for_${title}"
@@ -104,6 +103,7 @@ define monitoring_check::server_side (
     low_flap_threshold    => $low_flap_threshold,
     high_flap_threshold   => $high_flap_threshold,
     can_override          => $can_override,
+    source                => $source,
   }
 
 }

--- a/spec/defines/monitoring_check_spec.rb
+++ b/spec/defines/monitoring_check_spec.rb
@@ -269,10 +269,9 @@ describe 'monitoring_check' do
         "team"               => "operations",
         "notification_email" => "undef",
         "habitat"            => "somehabitat",
-        "source"             => "mysource",
         "tags"               => [],
         }
-      )}
+      ).with_source('mysource') }
     end
     context "with tags" do
       let(:facts) { { :habitat => "somehabitat", :lsbdistid => 'Ubuntu', :osfamily => 'Debian', :lsbdistcodename => 'lucid', :operatingsystem => 'Ubuntu', :ipaddress => '127.0.0.1', :puppetversion => '3.6.2' } }

--- a/spec/defines/server_side_spec.rb
+++ b/spec/defines/server_side_spec.rb
@@ -33,11 +33,11 @@ describe 'monitoring_check::server_side' do
       should contain_class('monitoring_check::server_side::install')
       should contain_monitoring_check('server_side_placeholder_for_example1') \
                .with_command(/check_server_side.rb/) \
+               .with_source('baz') \
                .with_sensu_custom({
                  'actual_command' => 'foo',
                  'actual_name'    => 'example1',
                  'actual_handlers'=> [ 'default' ],
-                 'source'         => 'baz'
                })
     }
   end
@@ -50,11 +50,11 @@ describe 'monitoring_check::server_side' do
 
     it {
       should contain_monitoring_check('server_side_placeholder_for_example1') \
+        .with_source('baz') \
         .with_sensu_custom({
           'actual_command' => 'foo',
           'actual_name'    => 'hello_world',
           'actual_handlers'=> [ 'foo' ],
-          'source'         => 'baz'
         })
     }
   end


### PR DESCRIPTION
This change makes us more compliant with newer sensu-puppet, which now has "source" parameter on sensu::check. As a result, we no longer have to pass "source" through "custom" param.

The dark side of this change is that it makes us not compatible with older versions of sensu-puppet.

@solarkennedy - my plan is to prepare an internal r10k change and merge this PR right before shipping it all in one. Looking for a shipit on this PR but please don't merge it yet.