### PR TITLE
more flexible way to manage how events are handled

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,7 +114,7 @@ GEM
     rspec-expectations (2.14.5)
       diff-lcs (>= 1.1.3, < 2.0)
     rspec-mocks (2.14.6)
-    rspec-puppet (1.0.1)
+    rspec-puppet (2.2.0)
       rspec
     rspec-puppet-utils (2.0.4)
     rspec-system (2.8.0)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -136,7 +136,11 @@
 define monitoring_check (
   $command,
   $runbook,
-  $handlers              = ['default'],
+  $handlers              = pick(
+                             hiera("monitoring_check::handlers::${title}", undef),
+                             hiera('monitoring_check::handlers', undef),
+                             ['default']
+                           ),
   $needs_sudo            = false,
   $sudo_user             = 'root',
   $check_every           = '1m',

--- a/spec/defines/monitoring_check_spec.rb
+++ b/spec/defines/monitoring_check_spec.rb
@@ -65,6 +65,40 @@ describe 'monitoring_check' do
       end
     end
 
+    context 'with non-empty handlers overrides' do
+      let(:params) {{ :command => 'foo', :runbook => 'http://gronk' }}
+      let(:hiera_data) {{
+        'sensu_handlers::teams' => { 'operations' => { } },
+        'monitoring_check::handlers' => ['bar','baz']
+      }}
+      it {
+        should contain_sensu__check('examplecheck').with_handlers(['bar','baz'])
+      }
+    end
+
+    context 'with empty handlers overrides' do
+      let(:params) {{ :command => 'foo', :runbook => 'http://gronk' }}
+      let(:hiera_data) {{
+        'sensu_handlers::teams' => { 'operations' => { } },
+        'monitoring_check::handlers' => []
+      }}
+      it {
+        should contain_sensu__check('examplecheck').with_handlers([])
+      }
+    end
+
+    context 'with check-specific handlers overrides' do
+      let(:params) {{ :command => 'foo', :runbook => 'http://gronk' }}
+      let(:hiera_data) {{
+        'sensu_handlers::teams' => { 'operations' => { } },
+        'monitoring_check::handlers' => ['foo'],
+        'monitoring_check::handlers::examplecheck' => ['qux'],
+      }}
+      it {
+        should contain_sensu__check('examplecheck').with_handlers(['qux'])
+      }
+    end
+
     context "bad runbook (not a uri)" do
       let(:params) { {:command => 'bar', :runbook => 'gronk'} }
       it do


### PR DESCRIPTION
This gives us more flexibility to manage how each check is handled in each environment, region, etc.

See internal OPS-8177 for a specific use case.

For some reason, had to upgrade rspec-puppet - tests were failing with hiera data leaking between contexts, which made no sense to me - upgrade fixed it.