### PR TITLE
Adding support to pass the subdue option into sensu::check

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -6,7 +6,7 @@ fixtures:
         ref: 530bb59a8d593bf664868dccd0ca2e84e8ae50f9
     sensu:
         repo: 'git://github.com/sensu/sensu-puppet.git'
-        ref: 9ba0abf38f1a0971bcd044b1bd51b58ec95783d9
+        ref: 53b785e86e0b510cb49d1c90ae01ea1d37b19b43
     apt:
         repo: 'git://github.com/puppetlabs/puppetlabs-apt.git'
         ref: 2.1.0

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -128,6 +128,10 @@
 # An array of arbitrary tags that can be used in handlers for different metadata needs
 # such as labels in JIRA handlers. This is optional and is empty by default
 #
+# [*subdue*]
+# A hash the determines if and when a check should be silenced for a peroid of time,
+# such as within working hours.
+#
 # This, by default allows you to set the $::override_sensu_checks_to fact
 # in /etc/facter/facts.d to stop checks on a single machine from alerting via the
 # normal mechanism. Setting this to false will stop this mechanism from applying
@@ -159,6 +163,7 @@ define monitoring_check (
   $source                = undef,
   $can_override          = true,
   $tags                  = [],
+  $subdue                = {},
 ) {
 
   include monitoring_check::params
@@ -181,6 +186,7 @@ define monitoring_check (
 
   validate_array($handlers)
   validate_hash($sensu_custom)
+  validate_hash($subdue)
 
   $interval_s = human_time_to_seconds($check_every)
   validate_re($interval_s, '^\d+$')
@@ -260,6 +266,7 @@ define monitoring_check (
       dependencies        => any2array($dependencies),
       custom              => $custom,
       source              => $source,
+      subdue              => $subdue,
     }
   }
 }


### PR DESCRIPTION
Recently merged PR into sensu-puppet added support for the subdue option on sensu::check. It would be useful to also have this feature in monitoring_check

Ref: https://github.com/sensu/sensu-puppet/pull/440