### PR TITLE
better compat with sensu-puppet for subdue param

### DIFF
--- a/spec/defines/monitoring_check_spec.rb
+++ b/spec/defines/monitoring_check_spec.rb
@@ -37,6 +37,7 @@ describe 'monitoring_check' do
           .with_ensure('present') \
           .with_handlers('default') \
           .with_interval(default_interval) \
+          .without_subdue \
           .with_command('bar') \
           .with_custom({
             "alert_after"        => "0",
@@ -326,6 +327,16 @@ describe 'monitoring_check' do
         "tags"               => ['first_tag','second_tag'],
         }
       )}
+    end
+
+    context 'with subdue' do
+      let(:params) {{
+        :command => 'foo', :runbook => 'http://gronk',
+        :subdue => { 'bar' => 'baz' }
+      }}
+      it {
+        should contain_sensu__check('examplecheck').with_subdue('bar' => 'baz')
+      }
     end
   end
 


### PR DESCRIPTION
Our internal sensu-puppet doesn't have subdue param on sensu::check yet because this change was merged fairly recently.

This change introduces a simple compat mechanism to allow us and anybody else who's not running fairly recent sensu-puppet, to continue using monitoring_check.