### PR TITLE
Make the error useful when Sensu hasn't been included.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -262,6 +262,9 @@ define monitoring_check (
   $custom = merge($with_override, $sensu_custom)
 
   if str2bool($use_sensu) {
+    if !defined(Class['sensu']) {
+      fail("monitoring_check $title defined before the sensu class was included")
+    }
     $sensu_check_params = delete_undef_values({
       handlers            => $handlers,
       command             => $real_command,


### PR DESCRIPTION
This transforms the error message from something like:
Unknown variable: '::sensu::check_notify'. at /etc/puppet/environments/masterbranch/vendor/modules/sensu/manifests/check.pp:147:28
into the much more helpful:
Error while evaluating a Function Call, monitoring_check local_smtp defined before the sensu class was included at /etc/puppet/environments/masterbranch/vendor/modules/monitoring_check/manifests/init.pp:266:7