### PR TITLE
Add tags to server side checks

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -187,6 +187,7 @@ define monitoring_check (
   $team_names = join(keys($team_data), '|')
   validate_re($team, "^(${team_names})$")
   validate_bool($ticket)
+  validate_array($tags)
 
   validate_array($handlers)
   validate_hash($sensu_custom)

--- a/manifests/server_side.pp
+++ b/manifests/server_side.pp
@@ -64,9 +64,11 @@ define monitoring_check::server_side (
   $low_flap_threshold    = undef,
   $high_flap_threshold   = undef,
   $can_override          = true,
+  $tags                  = [],
 ) {
   validate_string($source)
   validate_string($event_name)
+  validate_array($tags)
 
   include monitoring_check::server_side::install
 
@@ -103,6 +105,7 @@ define monitoring_check::server_side (
     low_flap_threshold    => $low_flap_threshold,
     high_flap_threshold   => $high_flap_threshold,
     can_override          => $can_override,
+    tags                  => $tags,
     source                => $source,
   }
 


### PR DESCRIPTION
This is useful for passing extra information from server side checks that would be otherwise unavailable.