### PR TITLE
Automatically inject executor hostname into server side checks

### DIFF
--- a/manifests/server_side.pp
+++ b/manifests/server_side.pp
@@ -105,7 +105,7 @@ define monitoring_check::server_side (
     low_flap_threshold    => $low_flap_threshold,
     high_flap_threshold   => $high_flap_threshold,
     can_override          => $can_override,
-    tags                  => $tags,
+    tags                  => flatten([['server_side', "executed_by ${::fqdn}"], $tags]),
     source                => $source,
   }
 

--- a/spec/defines/server_side_spec.rb
+++ b/spec/defines/server_side_spec.rb
@@ -26,14 +26,18 @@ describe 'monitoring_check::server_side' do
   context 'by default' do
     let(:params) {{
       :command => 'foo', :runbook => 'y/bar', :source => 'baz',
-      :team => 'qux',
+      :team => 'qux', :tags => ['test']
     }}
+    let(:facts) {{
+      :fqdn => 'host1'
+      }}
 
     it {
       should contain_class('monitoring_check::server_side::install')
       should contain_monitoring_check('server_side_placeholder_for_example1') \
                .with_command(/check_server_side.rb/) \
                .with_source('baz') \
+               .with_tags(['test', 'server_side', 'executed_by host1'])
                .with_sensu_custom({
                  'actual_command' => 'foo',
                  'actual_name'    => 'example1',
@@ -69,5 +73,5 @@ describe 'monitoring_check::server_side' do
       expect { should compile }.to raise_error(/not a string/)
     }
   end
-  
+
 end

--- a/spec/defines/server_side_spec.rb
+++ b/spec/defines/server_side_spec.rb
@@ -29,7 +29,9 @@ describe 'monitoring_check::server_side' do
       :team => 'qux', :tags => ['test']
     }}
     let(:facts) {{
-      :fqdn => 'host1'
+      :fqdn => 'host1',
+      :osfamily => 'debian',
+      :lsbdistid => 'lucid'
       }}
 
     it {
@@ -37,7 +39,7 @@ describe 'monitoring_check::server_side' do
       should contain_monitoring_check('server_side_placeholder_for_example1') \
                .with_command(/check_server_side.rb/) \
                .with_source('baz') \
-               .with_tags(['test', 'server_side', 'executed_by host1'])
+               .with_tags(['server_side', 'executed_by host1', 'test'])
                .with_sensu_custom({
                  'actual_command' => 'foo',
                  'actual_name'    => 'example1',

--- a/spec/defines/server_side_spec.rb
+++ b/spec/defines/server_side_spec.rb
@@ -9,13 +9,14 @@ describe 'monitoring_check::server_side' do
   }}
 
   let(:facts) {{
-    :ipaddress => '127.0.0.1',
-    :osfamily => 'Debian',
-    :lsbdistid => 'Ubuntu',
-    :lsbdistcodename => 'Lucid',
-    :operatingsystem => 'Ubuntu',
-    :puppetversion => '3.6.2',
-    :habitat       => 'somehabitat',
+    :ipaddress        => '127.0.0.1',
+    :osfamily         => 'Debian',
+    :lsbdistid        => 'Ubuntu',
+    :lsbdistcodename  => 'Lucid',
+    :operatingsystem  => 'Ubuntu',
+    :puppetversion    => '3.6.2',
+    :habitat          => 'somehabitat',
+    :fqdn             => 'host1',
   }}
 
   let(:pre_condition) { %q{
@@ -28,11 +29,6 @@ describe 'monitoring_check::server_side' do
       :command => 'foo', :runbook => 'y/bar', :source => 'baz',
       :team => 'qux', :tags => ['test']
     }}
-    let(:facts) {{
-      :fqdn => 'host1',
-      :osfamily => 'debian',
-      :lsbdistid => 'lucid'
-      }}
 
     it {
       should contain_class('monitoring_check::server_side::install')


### PR DESCRIPTION
This removes manual work.