### PR TITLE
use UNKNOWN status for internal exceptions in check_cluster 

### DIFF
--- a/spec/unit/check_cluster_spec.rb
+++ b/spec/unit/check_cluster_spec.rb
@@ -94,15 +94,15 @@ describe CheckCluster do
         expect_status :critical, /rspec error/
         check.run
       end
-
-      it "when SocketError happened" do
-        expect(TinyRedis::Mutex).to receive(:new).and_raise SocketError
-        expect_status :critical, /SocketError: 127.0.0.1:7777/
-        check.run
-      end
     end
 
     context "should be UNKNOWN" do
+      it "when SocketError happens" do
+        expect(TinyRedis::Mutex).to receive(:new).and_raise SocketError
+        expect_status :unknown, /127.0.0.1:7777: SocketError$/
+        check.run
+      end
+
       it "when wrong version of sensu" do
         stub_const("Sensu::VERSION", "0.12")
         expect_status :unknown, "Sensu <0.13 is not supported"


### PR DESCRIPTION
It will prevent generating CRITICAL alert when check_cluster can't connect to redis due to DNS issues.
Also it should not alert as CRITICAL when there are no hosts with a cluster check in a region.