### PR TITLE
Add auto remediation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,9 @@ before_install:
   - gem install bundler
   - rm Gemfile.lock || true
 rvm:
-  - 2.1.2
+  - 2.2
 sudo: false
 script: bundle exec rake spec
 env:
   matrix:
   - PUPPET_VERSION="~> 3.6.2" STRICT_VARIABLES=yes
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ before_install:
   - gem install bundler
   - rm Gemfile.lock || true
 rvm:
-  - 2.2
+  - 2.1.2
 sudo: false
 script: bundle exec rake spec
 env:

--- a/files/remediation.sh
+++ b/files/remediation.sh
@@ -28,7 +28,7 @@ done
 
 CHECK_OUTPUT=$($CHECK)
 CHECK_EXITCODE=$?
-if [ $CHECK_EXITCODE -ne 0 ]; then
+if [ $CHECK_EXITCODE -eq 2 ]; then
 # The check failed. Lets try remediation
   if [ -f "/tmp/$NAME" ]; then
     # We've tried this before. Let's see if we have retries left

--- a/files/remediation.sh
+++ b/files/remediation.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+# Takes a check command, and an action command
+# If the action doesn't return a 0, the action is run and the output is returned
+
+RETRIES=1
+echo $1
+while getopts "n:c:a:r:" arg; do
+  case $arg in
+  n)
+    # The name of the check we're running
+    NAME=$OPTARG
+    ;;
+  c)
+    # The check that we're running
+    CHECK=$OPTARG
+    ;;
+  a)
+    # The action to take in the case of a non 0 exit
+    ACTION=$OPTARG
+    ;;
+  r)
+    # Number of times to retry the action
+    RETRIES=$OPTARG
+    ;;
+  esac
+done
+
+CHECK_OUTPUT=$($CHECK)
+CHECK_EXITCODE=$?
+if [ $CHECK_EXITCODE -ne 0 ]; then
+# The check failed. Lets try remediation
+  if [ -f "/tmp/$NAME" ]; then
+    # We've tried this before. Let's see if we have retries left
+    ATTEMPTS=`cat /tmp/$NAME`
+    if [ $ATTEMPTS -ge $RETRIES ]; then
+      CHECK_EXITCODE=2
+    fi
+    ATTEMPTS=$((ATTEMPTS + 1))
+    `echo $ATTEMPTS > /tmp/$NAME`
+  else
+    ACTION_OUTPUT=$($ACTION)
+    ACTION_EXITCODE=$?
+    CHECK_EXITCODE=0
+    `echo 1 > /tmp/$NAME`
+
+   fi
+  CHECK_OUTPUT="$CHECK \n \n$CHECK_OUTPUT \n \nAction Command: $ACTION \n \nRetry Attempt: $ATTEMPTS\n \n \n$ACTION_OUTPUT"
+else
+  # The check has succeeded. Let's clean up
+  if [ -f /tmp/$NAME ]; then
+    `rm /tmp/$NAME`
+  fi
+fi
+
+echo -e "$CHECK_OUTPUT"
+exit $CHECK_EXITCODE

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -196,7 +196,6 @@ define monitoring_check (
   validate_re($team, "^(${team_names})$")
   validate_bool($ticket)
   validate_array($tags)
-  validate_bool($use_remediation)
 
   validate_array($handlers)
   validate_hash($sensu_custom)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -103,9 +103,6 @@
 # These will override any parameters configured by the wrapper.
 # Defaults to an empty hash.
 #
-# [*use_remediation*]
-# Should a script run automatically when a check fails?
-#
 # [*remediation_action*]
 # Which script should run when a check fails?
 #
@@ -171,8 +168,7 @@ define monitoring_check (
   $dependencies          = [],
   $use_sensu             = hiera('sensu_enabled', true),
   $sensu_custom          = {},
-  $use_remediation       = false,
-  $remediation_action    = '',
+  $remediation_action    = undef,
   $remediation_retries   = 1,
   $low_flap_threshold    = undef,
   $high_flap_threshold   = undef,
@@ -233,13 +229,8 @@ define monitoring_check (
     $irc_channel_array = $team_hash[$team]['notifications_irc_channel']
   }
 
-  if $use_remediation {
-    file { "${monitoring_check::params::etc_dir}/plugins/remediation.sh":
-      owner  => $monitoring_check::params::user,
-      group  => $monitoring_check::params::group,
-      mode   => '0555',
-      source => 'puppet:///modules/monitoring_check/remediation.sh',
-    }
+  if $remediation_action != undef {
+    include monitoring_check::remediation
 
     validate_re($remediation_action, '^/.*', "Your command, ${remediation_action}, must use a full path")
     validate_integer($remediation_retries)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -235,7 +235,10 @@ define monitoring_check (
     validate_re($remediation_action, '^/.*', "Your command, ${remediation_action}, must use a full path")
     validate_integer($remediation_retries)
 
-    $sudo_command = "${monitoring_check::params::etc_dir}/plugins/remediation.sh -n \"${name}\" -c \"${command}\" -a \"${remediation_action}\" -r ${remediation_retries}"
+    $safe_command = shell_escape($command)
+    $safe_remediation_action = shell_escape($remediation_action)
+
+    $sudo_command = "${monitoring_check::params::etc_dir}/plugins/remediation.sh -n \"${name}\" -c \"${safe_command}\" -a \"${safe_remediation_action}\" -r ${remediation_retries}"
   } else {
     $sudo_command = $command
   }

--- a/manifests/remediation.pp
+++ b/manifests/remediation.pp
@@ -1,0 +1,13 @@
+# == Define: monitoring_check::remediation
+#
+# Installs the remediation check
+#
+#
+class monitoring_check::remediation {
+  file { "${monitoring_check::params::etc_dir}/plugins/remediation.sh":
+    owner  => $monitoring_check::params::user,
+    group  => $monitoring_check::params::group,
+    mode   => '0755',
+    source => 'puppet:///modules/monitoring_check/remediation.sh',
+  }
+}

--- a/spec/defines/monitoring_check_spec.rb
+++ b/spec/defines/monitoring_check_spec.rb
@@ -335,9 +335,9 @@ describe 'monitoring_check' do
     end
     context "with remediation" do
       let(:facts) { { :habitat => "somehabitat", :lsbdistid => 'Ubuntu', :osfamily => 'Debian', :lsbdistcodename => 'lucid', :operatingsystem => 'Ubuntu', :ipaddress => '127.0.0.1', :puppetversion => '3.6.2' } }
-      let(:params) { {:command => '/bin/bar', :runbook => 'http://gronk', :use_remediation => true, :remediation_action => '/bin/ls /', :remediation_retries => 2 } }
+      let(:params) { {:command => '/bin/bar', :runbook => 'http://gronk', :remediation_action => '/bin/ls /', :remediation_retries => 2 } }
       it { should contain_sensu__check('examplecheck')
-        .with_command('/etc/sensu/plugins/remediation.sh -n "examplecheck" -c "/bin/bar" -a "/bin/ls /" -r 2') \
+        .with_command('/etc/sensu/plugins/remediation.sh -n "examplecheck" -c "/bin/bar" -a "/bin/ls\ /" -r 2') \
       }
     end
 

--- a/spec/defines/monitoring_check_spec.rb
+++ b/spec/defines/monitoring_check_spec.rb
@@ -333,6 +333,14 @@ describe 'monitoring_check' do
         }
       )}
     end
+    context "with remediation" do
+      let(:facts) { { :habitat => "somehabitat", :lsbdistid => 'Ubuntu', :osfamily => 'Debian', :lsbdistcodename => 'lucid', :operatingsystem => 'Ubuntu', :ipaddress => '127.0.0.1', :puppetversion => '3.6.2' } }
+      let(:params) { {:command => '/bin/bar', :runbook => 'http://gronk', :use_remediation => true, :remediation_action => '/bin/ls /', :remediation_retries => 2 } }
+      it { should contain_sensu__check('examplecheck')
+        .with_command('/etc/sensu/plugins/remediation.sh -n "examplecheck" -c "/bin/bar" -a "/bin/ls /" -r 2') \
+      }
+    end
+
 
     context 'with subdue' do
       let(:params) {{


### PR DESCRIPTION
This is a bit of a first pass/WIP of auto remediation.

Adding 3 lines to the monitoring_check definition:
use_remediation
remediation_action
remediation_retries

will wrap the check in a script. The script will run the check as normal. If it passes, the wrapper will pass the check output to stdout, and pass the check exit code correct. If the check fails, it will run the remediation script, recording that it has run it in a file called /tmp/$name. The number of times the remediation action will run can be set. Only once this number of attempts has been reached will the check properly fail, and page/ticket as appropriate.

It's a bit janky - some of the bash output could be cleaned up, and it may make more sense to move this to Ruby, but it works for now.