### PR TITLE
add --num-critical to check-cluster.rb

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ before_install:
   - rm Gemfile.lock || true
 rvm:
   - 2.1.2
-  - 2.2.3
 sudo: false
 script: bundle exec rake spec
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ before_install:
   - rm Gemfile.lock || true
 rvm:
   - 2.1.2
+  - 2.2.3
 sudo: false
 script: bundle exec rake spec
 env:

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem 'puppet-syntax'
 gem 'puppet', ENV['PUPPET_VERSION'] || '~> 3.8.0'
 gem 'vagrant-wrapper'
 gem 'rspec-puppet-utils'
+gem 'listen', '< 3.1'
 
 gem 'hiera-puppet-helper',
   :git => 'https://github.com/bobtfish/hiera-puppet-helper.git',

--- a/files/check-cluster.rb
+++ b/files/check-cluster.rb
@@ -45,14 +45,14 @@ class CheckCluster < Sensu::Plugin::Check::CLI
     :description => "Aggregate CHECK name",
     :required => true
 
-  option :critical,
+  option :pct_critical,
     :short => "-C PERCENT",
     :long => "--critical PERCENT",
     :description => "PERCENT non-ok before critical",
     :proc => proc {|a| a.to_i },
     :default => 80
 
-  options :num_critical,
+  option :num_critical,
     :short => '-u NUM',
     :long => '--num-critical NUM',
     :description => 'NUMBER (not percent) of non-ok before critical',
@@ -172,7 +172,7 @@ private
     message = "#{ok} OK out of #{eff_total} total."
     message << " #{silenced} silenced." if config[:silenced] && silenced > 0
     message << " #{stale.size} stale." unless stale.empty?
-    message << " #{ok_pct}% OK, #{config[:critical]}% threshold"
+    message << " #{ok_pct}% OK, #{config[:pct_critical]}% threshold"
     message << "\nStale hosts: #{stale.map{|host| host.split('.').first}.sort[0..10].join ','}" unless stale.empty?
     message << "\nFailing hosts: #{failing.map{|host| host.split('.').first}.sort[0..10].join ','}" unless failing.empty?
     message << "\nMinimum number of hosts required is #{config[:min_nodes]} and only #{ok} found" if ok < config[:min_nodes]
@@ -180,7 +180,7 @@ private
     if config[:num_critical]
       state = ok >= config[:num_critical] ? 'OK': 'CRITICAL'
     else
-      state = ok_pct >= config[:critical] ? 'OK' : 'CRITICAL'
+      state = ok_pct >= config[:pct_critical] ? 'OK' : 'CRITICAL'
     end
     state = ok >= config[:min_nodes] ? state : 'CRITICAL'
     return state, message

--- a/files/check-cluster.rb
+++ b/files/check-cluster.rb
@@ -52,6 +52,13 @@ class CheckCluster < Sensu::Plugin::Check::CLI
     :proc => proc {|a| a.to_i },
     :default => 80
 
+  options :num_critical,
+    :short => '-u NUM',
+    :long => '--num-critical NUM',
+    :description => 'NUMBER (not percent) of non-ok before critical',
+    :proc => proc {|a| a.to_i },
+    :required => false
+
   option :silenced,
     :short => "-S yes",
     :long => "--silenced yes",
@@ -170,7 +177,11 @@ private
     message << "\nFailing hosts: #{failing.map{|host| host.split('.').first}.sort[0..10].join ','}" unless failing.empty?
     message << "\nMinimum number of hosts required is #{config[:min_nodes]} and only #{ok} found" if ok < config[:min_nodes]
 
-    state = ok_pct >= config[:critical] ? 'OK' : 'CRITICAL'
+    if config[:num_critical]
+      state = ok >= config[:num_critical] ? 'OK': 'CRITICAL'
+    else
+      state = ok_pct >= config[:critical] ? 'OK' : 'CRITICAL'
+    end
     state = ok >= config[:min_nodes] ? state : 'CRITICAL'
     return state, message
   end

--- a/spec/defines/monitoring_check_spec.rb
+++ b/spec/defines/monitoring_check_spec.rb
@@ -337,7 +337,7 @@ describe 'monitoring_check' do
       let(:facts) { { :habitat => "somehabitat", :lsbdistid => 'Ubuntu', :osfamily => 'Debian', :lsbdistcodename => 'lucid', :operatingsystem => 'Ubuntu', :ipaddress => '127.0.0.1', :puppetversion => '3.6.2' } }
       let(:params) { {:command => '/bin/bar', :runbook => 'http://gronk', :remediation_action => '/bin/ls /', :remediation_retries => 2 } }
       it { should contain_sensu__check('examplecheck')
-        .with_command('/etc/sensu/plugins/remediation.sh -n "examplecheck" -c "/bin/bar" -a "/bin/ls\ /" -r 2') \
+        .with_command('/etc/sensu/plugins/remediation.sh -n "examplecheck" -c /bin/bar -a /bin/ls\ / -r 2') \
       }
     end
 

--- a/spec/unit/check_cluster_spec.rb
+++ b/spec/unit/check_cluster_spec.rb
@@ -6,7 +6,7 @@ describe CheckCluster do
     { :check        => :test_check,
       :cluster_name => :test_cluster,
       :warning      => 30,
-      :critical     => 50,
+      :pct_critical => 50,
       :min_nodes    => 0 }
   end
 


### PR DESCRIPTION
For situations where we need to trigger events not based on percentages but based on absolute number of hosts.

I want to experiment with some events using this mode. The change itself looks quite small so worst case scenario we will end up not using it and could remove it in the future.