### PR TITLE
handle exceptions better in last_execution method in check-cluster.rb

### DIFF
--- a/files/check-cluster.rb
+++ b/files/check-cluster.rb
@@ -262,7 +262,7 @@ class RedisCheckAggregate
     servers.inject({}) do |hash, server|
       hash.merge!(
         server => JSON.parse(@redis.get("result:#{server}:#@check")).
-                    values_at("executed", "status"))
+                    values_at("executed", "status")) rescue []
     end
   end
 


### PR DESCRIPTION
See internal OPSALERTS-10684 for exact exception.

Looks to me like after we get a list of hosts in `find_servers`, we could run into a race condition where we request json for a given server's check result from redis (in `last_execution` method) but don't get it. Suspect it's possible due to transient issues with redis or if host disappeared between a call to `find_servers` and a call to `last_execution` (say it was a spot instance).

Here we just make sure not to raise an exception. This host will have [] as its value as a result and will be filtered out in the first line of `summary` method.