### PR TITLE
improve exceptions handling harder

### DIFF
--- a/files/check-cluster.rb
+++ b/files/check-cluster.rb
@@ -260,9 +260,9 @@ class RedisCheckAggregate
   # { server_name => [timestamp, status], ... }
   def last_execution(servers)
     servers.inject({}) do |hash, server|
-      hash.merge!(
-        server => JSON.parse(@redis.get("result:#{server}:#@check")).
-                    values_at("executed", "status")) rescue []
+      values = JSON.parse(@redis.get("result:#{server}:#@check")).
+                 values_at("executed", "status") rescue []
+      hash.merge!(server => values)
     end
   end
 


### PR DESCRIPTION
My previous fix was bad, 'rescue []' ended up being applied to entire merge!

This fixes it.