### PR TITLE
Ticket 'false'/'true' gets converted to bool

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -194,7 +194,6 @@ define monitoring_check (
   }
   $team_names = join(keys($team_data), '|')
   validate_re($team, "^(${team_names})$")
-  $ticket_real = str2bool($ticket)
   validate_array($tags)
 
   validate_array($handlers)
@@ -267,7 +266,7 @@ define monitoring_check (
     team               => $team,
     irc_channels       => $irc_channel_array,
     notification_email => $notification_email,
-    ticket             => $ticket_real,
+    ticket             => str2bool($ticket),
     project            => $project,
     page               => str2bool($page),
     tip                => $tip,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -194,12 +194,7 @@ define monitoring_check (
   }
   $team_names = join(keys($team_data), '|')
   validate_re($team, "^(${team_names})$")
-  $ticket_real = $ticket ? {
-    'true' => true,
-    'false' => false,
-    default => $ticket,
-  }
-  validate_bool($ticket_real)
+  $ticket_real = str2bool($ticket)
   validate_array($tags)
 
   validate_array($handlers)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -194,7 +194,12 @@ define monitoring_check (
   }
   $team_names = join(keys($team_data), '|')
   validate_re($team, "^(${team_names})$")
-  validate_bool($ticket)
+  $ticket_real = $ticket ? {
+    'true' => true,
+    'false' => false,
+    default => $ticket,
+  }
+  validate_bool($ticket_real)
   validate_array($tags)
 
   validate_array($handlers)
@@ -267,7 +272,7 @@ define monitoring_check (
     team               => $team,
     irc_channels       => $irc_channel_array,
     notification_email => $notification_email,
-    ticket             => $ticket,
+    ticket             => $ticket_real,
     project            => $project,
     page               => str2bool($page),
     tip                => $tip,


### PR DESCRIPTION
This is so that elsewhere we can do:

ticket: "%{hiera('some::hiera::value')}"

to get an override into a cluster check. 

Deep merge doesn't do what I wanted, so I'm doing this instead, cc @somic 