### PR TITLE
Read $subdue param's default value from hiera

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -175,7 +175,7 @@ define monitoring_check (
   $source                = undef,
   $can_override          = true,
   $tags                  = [],
-  $subdue                = undef,
+  $subdue                = hiera("monitoring_check::subdue", undef),
 ) {
 
   include monitoring_check::params


### PR DESCRIPTION
Having this hiera would make it more flexible rather than passing it to individual checks.