### PR TITLE
handle HTTP 400 from sensu api better

### DIFF
--- a/files/fleet_check.rb
+++ b/files/fleet_check.rb
@@ -150,7 +150,7 @@ class SensuFleetCheck < Sensu::Plugin::Check::CLI
     if redis.sismember('clients', sensu_client) == 1
       api_response = api_request(:Delete, "/events/#{sensu_client}/#{event_name}")
     end
-    if api_response.nil? || api_response.code =~ /20/
+    if api_response.nil? || api_response.code =~ /^20/ || api_response.code == '404'
       redis.lrem(redis_key, 1, sensu_client)
     end
   end


### PR DESCRIPTION
When we try to resolve an event through API and get HTTP 404, it means event has already been resolved or client no longer exists in sensu.

In either case, we should remove this client from our list of clients where this check has failed (which we maintain in `fleet_check:#{check_name}` redis key).