### PR TITLE
Fixing the help for -C and -u options to match actual functionality

### DIFF
--- a/files/check-cluster.rb
+++ b/files/check-cluster.rb
@@ -48,14 +48,14 @@ class CheckCluster < Sensu::Plugin::Check::CLI
   option :pct_critical,
     :short => "-C PERCENT",
     :long => "--critical PERCENT",
-    :description => "PERCENT non-ok before critical",
+    :description => "PERCENT minimum OK threshold (below this number, send alert)",
     :proc => proc {|a| a.to_i },
     :default => 80
 
   option :num_critical,
     :short => '-u NUM',
     :long => '--num-critical NUM',
-    :description => 'NUMBER (not percent) of non-ok before critical',
+    :description => 'NUMBER minimum OK threshold (below this number, send alert)',
     :proc => proc {|a| a.to_i },
     :required => false
 


### PR DESCRIPTION
I was working with this the other week and noticed that the -C and -u options have help text that says the exact opposite of what they actually do. Instead of -C PERCENT being the minimum number bad before sending an alert, it's actually the minimum number *good* to keep from sending an alert. -u NUMBER appears to work the same way.