### PR TITLE
fix rescue in check-cluster.rb

### DIFF
--- a/files/check-cluster.rb
+++ b/files/check-cluster.rb
@@ -352,7 +352,8 @@ class RedisCheckAggregate
           "cluster_name"  # monitored cluster, not sensu cluster.
         )
         hash.merge!(server => values2)
-      rescue []
+      rescue
+        []
       end
     end
   end


### PR DESCRIPTION
This fixes ```Check failed to run: class or module required for rescue clause, ["/etc/sensu/plugins/check-cluster.rb:355```