### PR TITLE
add check_remote_sensu

### DIFF
--- a/files/check_remote_sensu.rb
+++ b/files/check_remote_sensu.rb
@@ -1,0 +1,85 @@
+#!/opt/sensu/embedded/bin/ruby
+
+$: << File.dirname(__FILE__)
+
+require 'rubygems'
+unless defined?(IN_RSPEC)
+  require 'sensu-plugin/utils'
+  require 'sensu-plugin/check/cli'
+end
+require 'tiny_redis'
+require 'socket'
+require 'json'
+
+class CheckRemoteSensu < Sensu::Plugin::Check::CLI
+
+  # let's get all sensu settings
+  include Sensu::Plugin::Utils
+
+  option :event,
+    :short       => '-e event',
+    :long        => '--event check_name',
+    :description => 'name of the event',
+    :required    => true
+
+  option :filter,
+    :short       => '-f filter',
+    :long        => '--filter filter',
+    :description => 'filter hosts to analyze',
+    :required    => true
+
+  option :redis_host,
+    :short       => '-h host',
+    :long        => '--redis-host host',
+    :description => 'redis host to use',
+    :required    => true
+
+  attr_accessor :good, :bad, :undefined
+
+  def run
+    @good = []
+    @bad = []
+    @undefined = []
+
+    redis.keys("result:*:#{config[:event]}").each do |key|
+      _, host, _ = key.split(/:/)
+      next unless redis.get("client:#{host}").include?(config[:filter])
+      check_result = JSON.parse(redis.get(key)) rescue nil
+      case check_result['status']
+        when 0
+          good << host
+        when 2
+          bad << host
+        else
+          undefined << host
+      end
+    end
+
+    unknown("No check results were found. #{message}") if (bad + good + undefined).empty?
+
+    bad.empty? ? ok(message) : critical(message)
+  end
+
+  def redis
+    @redis ||= TinyRedis::Client.new(host=config[:redis_host],
+                                     port=settings['redis']['port'])
+    @redis.ping
+    @redis
+  rescue => e
+    raise "Unable to connect to remote redis at #{config[:redis_host]} : #{e.message}"
+  end
+
+  def message
+    m = ""
+    m += message_part(bad, :critical) unless bad.empty?
+    m += message_part(good, :ok) unless good.empty?
+    m += message_part(undefined, :unknown) unless undefined.empty?
+    m += " Host filter applied during search: '#{config[:filter]}'."
+    m.gsub(/\s+/, ' ')
+  end
+
+  def message_part(list, status_string)
+    "#{config[:event]} is #{status_string} on these hosts: #{list.join(', ')}. "
+  end
+
+end

--- a/manifests/server_side/install.pp
+++ b/manifests/server_side/install.pp
@@ -18,4 +18,11 @@ class monitoring_check::server_side::install (
     mode   => '0444',
     source => 'puppet:///modules/monitoring_check/fleet_check.rb',
   }
+
+  file { '/etc/sensu/plugins/check_remote_sensu.rb':
+    owner  => 'sensu',
+    group  => 'sensu',
+    mode   => '0444',
+    source => 'puppet:///modules/monitoring_check/check_remote_sensu.rb',
+  }
 }


### PR DESCRIPTION
This is for internal OPSIMP-2475.

The idea is to let a sensu cluster check events in remote sensu cluster. This is useful if remote sensu cluster is for some reason unable to run handlers - such as, for example, unable to hit pagerduty due to Internet connectivity issue at remote region.