### PR TITLE
fix [] -> {} in last_execution in cluster check

### DIFF
--- a/files/check-cluster.rb
+++ b/files/check-cluster.rb
@@ -345,7 +345,6 @@ class RedisCheckAggregate
   def find_servers
     # TODO: reimplement using @redis.scan for webscale
     @servers ||= begin
-      keys = @redis.keys("result:*:#@check")
       keys = @redis.keys("result:*:#@check") || []
       raise NoServersFound if @raise_no_server_found && keys.empty?
       keys.map {|key| key.split(':')[1] }.reject {|s| s == @cluster_name }
@@ -365,7 +364,7 @@ class RedisCheckAggregate
         )
         hash.merge!(server => values2)
       rescue
-        {}
+        hash
       end
     end
   end

--- a/files/check-cluster.rb
+++ b/files/check-cluster.rb
@@ -365,7 +365,7 @@ class RedisCheckAggregate
         )
         hash.merge!(server => values2)
       rescue
-        []
+        {}
       end
     end
   end


### PR DESCRIPTION
I thought it was fixed but looks like it's not. Most recent occurrence is OPS-11608

@keymone @philipmulcahy @nosmo 