### PR TITLE
Don't attempt to set up remediation when sensu is disabled

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -228,18 +228,20 @@ define monitoring_check (
     $irc_channel_array = $team_hash[$team]['notifications_irc_channel']
   }
 
-  if $remediation_action != undef {
-    include monitoring_check::remediation
+  if str2bool($use_sensu) {
+    if $remediation_action != undef {
+      include monitoring_check::remediation
 
-    validate_re($remediation_action, '^/.*', "Your command, ${remediation_action}, must use a full path")
-    validate_integer($remediation_retries)
+      validate_re($remediation_action, '^/.*', "Your command, ${remediation_action}, must use a full path")
+      validate_integer($remediation_retries)
 
-    $safe_command = shell_escape($command)
-    $safe_remediation_action = shell_escape($remediation_action)
+      $safe_command = shell_escape($command)
+      $safe_remediation_action = shell_escape($remediation_action)
 
-    $sudo_command = "${monitoring_check::params::etc_dir}/plugins/remediation.sh -n \"${name}\" -c ${safe_command} -a ${safe_remediation_action} -r ${remediation_retries}"
-  } else {
-    $sudo_command = $command
+      $sudo_command = "${monitoring_check::params::etc_dir}/plugins/remediation.sh -n \"${name}\" -c ${safe_command} -a ${safe_remediation_action} -r ${remediation_retries}"
+    } else {
+      $sudo_command = $command
+    }
   }
 
   if str2bool($needs_sudo) {


### PR DESCRIPTION
When remediation is defined for a check on a host where sensu is disabled via sensu_enabled in hiera, the monitoring_check::remediation class will attempt to install the file regardless. This is at best undesirable but in the current arrangement the installation will attempt to use ```${monitoring_check::params::etc_dir}/plugins/remediation.sh```, which will not exist on a host where sensu is disabled. 

This change simply gates the installation of remediation actions based on whether sensu is enabled. 