### PR TITLE
Exclude cluster result rows from child row set

### DIFF
--- a/files/check-cluster.rb
+++ b/files/check-cluster.rb
@@ -339,7 +339,7 @@ class RedisCheckAggregate
   end
 
   def child_cluster_names()
-     last_execution(find_servers).values.map{|(_,_,name)| name if name && !name.empty?}.compact.uniq
+     last_execution(find_servers).values.map{|(t,_,name)| name if t && name && !name.empty?}.compact.uniq
   end
 
   def find_servers

--- a/files/check-cluster.rb
+++ b/files/check-cluster.rb
@@ -118,7 +118,6 @@ private
   # Sending cluster status (is cluster ok?) is delegated.
   # Check status (is check working?) is reported in this func.
   def run_single
-    puts "\nRUN_SINGLE\n"
     result = run_single_child
     code = EXIT_CODES[result[0].to_s.upcase]
     message = result[1]
@@ -131,8 +130,6 @@ private
   # Check status results (are checks working?) are collected and the worst ones
   # are combined and reported.
   def run_multi
-    puts "\nRUN_MULTI\n"
-    puts aggregator.child_cluster_names.join('; ')
     results = aggregator.child_cluster_names.map do |child_cluster_name|
       run_single_child(child_cluster_name)
     end 
@@ -147,9 +144,8 @@ private
           .select{|result| result[0]==worst_code}
           .map{|result| result[1]}
           .uniq
-          .join("\n")
+          .join(';')
       worst_method_name = EXIT_CODES.key(worst_code).downcase
-      puts "\nRUN_MULTI sending worst\n"
       send(worst_method_name, message)
     end
   end
@@ -157,7 +153,6 @@ private
   # Returns check status, message (is check working?), for possible aggregation.
   # Sends cluster status payload (is the cluster ok?)
   def run_single_child(child_cluster_name=nil)
-    puts "\nRUN_SINGLE_CHILD #{child_cluster_name}\n"
     lock_key = "lock:#{config[:cluster_name]}:#{config[:check]}"
     interval = cluster_check[:interval]
     staleness_interval = cluster_check[:staleness_interval] || cluster_check[:interval]
@@ -178,18 +173,18 @@ private
       return :ok, msg
     end 
 
-#    if config[:dryrun]
+    if config[:dryrun]
       return transaction_body.call
-#    else 
-#        mutex = TinyRedis::Mutex.new(redis, lock_key, interval, logger)
-#        mutex.run_with_lock_or_skip do
-#          return transaction_body.call
-#        end
-#    end
+    else 
+        mutex = TinyRedis::Mutex.new(redis, lock_key, interval, logger)
+        mutex.run_with_lock_or_skip do
+          return transaction_body.call
+        end
+    end
 
-#    if (ttl = mutex.ttl) && ttl >= 0
-#      return :ok, "Cluster check did not execute, lock expires in #{ttl}"
-#    end
+    if (ttl = mutex.ttl) && ttl >= 0
+      return :ok, "Cluster check did not execute, lock expires in #{ttl}"
+    end
 
     if ttl.nil?
       return :ok, "Cluster check did not execute, lock expired sooner than round-trip time to redis server"
@@ -248,11 +243,11 @@ private
     message << " #{silenced} silenced." if config[:silenced] && silenced > 0
     message << " #{stale.size} stale." unless stale.empty?
     if config[:num_critical]
-      message << " #{eff_total} OK, #{failing.size} FAIL, #{silenced} SILENT, #{stale.size} STALE, #{config[:num_critical]}; FAIL threshold: #{config[:num_critical]}.\n"
+      message << " #{eff_total} OK, #{failing.size} FAIL, #{silenced} SILENT, #{stale.size} STALE, #{config[:num_critical]}; FAIL threshold: #{config[:num_critical]}."
     else
-      message << " #{ok_pct}% OK, #{config[:pct_critical]}% threshold.\n"
+      message << " #{ok_pct}% OK, #{config[:pct_critical]}% threshold."
     end
-    message << "Stale hosts: #{stale.map{|host| host.split('.').first}.sort[0..10].join ','}" unless stale.empty?
+    message << "\nStale hosts: #{stale.map{|host| host.split('.').first}.sort[0..10].join ','}" unless stale.empty?
     message << "\nFailing hosts: #{failing.map{|host| host.split('.').first}.sort[0..10].join ','}" unless failing.empty?
     message << "\nMinimum number of hosts required is #{config[:min_nodes]} and only #{ok} found" if ok < config[:min_nodes]
 

--- a/files/check-cluster.rb
+++ b/files/check-cluster.rb
@@ -339,11 +339,7 @@ class RedisCheckAggregate
   end
 
   def child_cluster_names()
-#    last_execution(find_servers).values.select{|data| data[0]}.map{|data| data[2]}.uniq.reject{ |s| s == nil || s.empty? }
-#     last_execution(find_servers).values.select{|data| data[0]}.map{|data| data[2] if data[2] && !data[2].empty?}.compact.uniq
-#     last_execution(find_servers).values.select{|data| data[0]}.map{|(_,_,name)| name if name && !name.empty?}.compact.uniq
      last_execution(find_servers).values.map{|(_,_,name)| name if name && !name.empty?}.compact.uniq
-#    last_execution(find_servers).map{|(_,((_,_,n),_,_))| n if n && !"#{n}".empty?}.compact
   end
 
   def find_servers

--- a/files/check-cluster.rb
+++ b/files/check-cluster.rb
@@ -339,7 +339,7 @@ class RedisCheckAggregate
   end
 
   def child_cluster_names()
-     last_execution(find_servers).values.map{|(t,_,name)| name if t && name && !name.empty?}.compact.uniq
+     last_execution(find_servers).values.map{|(time,_,name)| name if time && name && !name.empty?}.compact.uniq
   end
 
   def find_servers

--- a/files/check-cluster.rb
+++ b/files/check-cluster.rb
@@ -339,7 +339,11 @@ class RedisCheckAggregate
   end
 
   def child_cluster_names()
-    last_execution(find_servers).values.select{|data| data[0]}.map{|data| data[2]}.uniq.reject{ |s| s == nil || s.empty? }
+#    last_execution(find_servers).values.select{|data| data[0]}.map{|data| data[2]}.uniq.reject{ |s| s == nil || s.empty? }
+#     last_execution(find_servers).values.select{|data| data[0]}.map{|data| data[2] if data[2] && !data[2].empty?}.compact.uniq
+#     last_execution(find_servers).values.select{|data| data[0]}.map{|(_,_,name)| name if name && !name.empty?}.compact.uniq
+     last_execution(find_servers).values.map{|(_,_,name)| name if name && !name.empty?}.compact.uniq
+#    last_execution(find_servers).map{|(_,((_,_,n),_,_))| n if n && !"#{n}".empty?}.compact
   end
 
   def find_servers

--- a/spec/unit/check_multi_cluster_spec.rb
+++ b/spec/unit/check_multi_cluster_spec.rb
@@ -207,7 +207,7 @@ describe CheckCluster do
           :critical,
           %r{
             Cluster:\scluster_1\n
-            0\sOK\sout\sof\s3\stotal.\s0%\sOK,\s50%\sthreshold.\n
+            0\sOK\sout\sof\s3\stotal.\s0%\sOK,\s50%\sthreshold.\n\n
             Failing\shosts:\s10-10-10-101-dcname,
                              10-10-10-111-dcname,
                              10-10-10-121-dcname
@@ -238,7 +238,7 @@ describe CheckCluster do
           :critical,
           %r{
             Cluster:\scluster_1\n
-            0\sOK\sout\sof\s3\stotal.\s0%\sOK,\s50%\sthreshold.\n
+            0\sOK\sout\sof\s3\stotal.\s0%\sOK,\s50%\sthreshold.\n\n
             Failing\shosts:\s10-10-10-101-dcname,
                              10-10-10-111-dcname,
                              10-10-10-121-dcname
@@ -250,7 +250,7 @@ describe CheckCluster do
           :critical,
           %r{
             Cluster:\scluster_2\n
-            0\sOK\sout\sof\s3\stotal.\s0%\sOK,\s50%\sthreshold.\n
+            0\sOK\sout\sof\s3\stotal.\s0%\sOK,\s50%\sthreshold.\n\n
             Failing\shosts:\s10-10-10-102-dcname,
                              10-10-10-112-dcname,
                              10-10-10-122-dcname

--- a/spec/unit/check_multi_cluster_spec.rb
+++ b/spec/unit/check_multi_cluster_spec.rb
@@ -207,7 +207,7 @@ describe CheckCluster do
           :critical,
           %r{
             Cluster:\scluster_1\n
-            0\sOK\sout\sof\s3\stotal.\s0%\sOK,\s50%\sthreshold.\n\n
+            0\sOK\sout\sof\s3\stotal.\s0%\sOK,\s50%\sthreshold.\n
             Failing\shosts:\s10-10-10-101-dcname,
                              10-10-10-111-dcname,
                              10-10-10-121-dcname
@@ -238,7 +238,7 @@ describe CheckCluster do
           :critical,
           %r{
             Cluster:\scluster_1\n
-            0\sOK\sout\sof\s3\stotal.\s0%\sOK,\s50%\sthreshold.\n\n
+            0\sOK\sout\sof\s3\stotal.\s0%\sOK,\s50%\sthreshold.\n
             Failing\shosts:\s10-10-10-101-dcname,
                              10-10-10-111-dcname,
                              10-10-10-121-dcname
@@ -250,7 +250,7 @@ describe CheckCluster do
           :critical,
           %r{
             Cluster:\scluster_2\n
-            0\sOK\sout\sof\s3\stotal.\s0%\sOK,\s50%\sthreshold.\n\n
+            0\sOK\sout\sof\s3\stotal.\s0%\sOK,\s50%\sthreshold.\n
             Failing\shosts:\s10-10-10-102-dcname,
                              10-10-10-112-dcname,
                              10-10-10-122-dcname


### PR DESCRIPTION
This change fixes a bug in multi-cluster mode whereby the set of client check results that is grouped by cluster_name wrongly includes the cluster_check (server) results, leading to "imaginary" nameless clusters being considered.