### PR TITLE
Cluster name extraction fix lock

### DIFF
--- a/spec/unit/check_cluster_spec.rb
+++ b/spec/unit/check_cluster_spec.rb
@@ -75,14 +75,10 @@ describe CheckCluster do
       end
 
       it "when lock was not acquired" do
-        puts "\nXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX starting test\n"
         redis.stub(:setnx).and_return 0
         redis.stub(:pttl).and_return 10000.0
         expect_status :ok, /expires in 10/
-        puts "\nXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX check.run starting\n"
         check.run
-        puts "\nXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX check.run finished\n"
-        puts "\nXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX check.run finished\n"
       end
 
       it "when lock expired" do

--- a/spec/unit/check_cluster_spec.rb
+++ b/spec/unit/check_cluster_spec.rb
@@ -75,10 +75,14 @@ describe CheckCluster do
       end
 
       it "when lock was not acquired" do
+        puts "\nXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX starting test\n"
         redis.stub(:setnx).and_return 0
         redis.stub(:pttl).and_return 10000.0
         expect_status :ok, /expires in 10/
+        puts "\nXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX check.run starting\n"
         check.run
+        puts "\nXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX check.run finished\n"
+        puts "\nXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX check.run finished\n"
       end
 
       it "when lock expired" do

--- a/spec/unit/check_multi_cluster_spec.rb
+++ b/spec/unit/check_multi_cluster_spec.rb
@@ -178,8 +178,12 @@ describe CheckCluster do
         end
         context "not ignoring nohosts" do
           let(:config) { super().merge ignore_nohosts: false }
+#          puts "CONFIG #{config}"
           it "should be noisy: we've said we care about missing hosts" do
-            expect{ check.run }.to raise_error(NoServersFound)
+            expect_status :unknown, /NoServersFound/
+            puts "\nXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX check.run starting\n"
+            check.run
+            puts "\nXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX check.run finished\n"
           end
         end
     end

--- a/spec/unit/check_multi_cluster_spec.rb
+++ b/spec/unit/check_multi_cluster_spec.rb
@@ -178,12 +178,9 @@ describe CheckCluster do
         end
         context "not ignoring nohosts" do
           let(:config) { super().merge ignore_nohosts: false }
-#          puts "CONFIG #{config}"
           it "should be noisy: we've said we care about missing hosts" do
             expect_status :unknown, /NoServersFound/
-            puts "\nXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX check.run starting\n"
             check.run
-            puts "\nXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX check.run finished\n"
           end
         end
     end


### PR DESCRIPTION
multi-cluster mode requires multiple rows to be written - and redis locks are not reentrant. This fix hoists the lock acquisition above the loop.