### PR TITLE
add sensu api client helper methods to SensuAPIUtil module

### DIFF
--- a/files/sensu_api_util.rb
+++ b/files/sensu_api_util.rb
@@ -1,0 +1,33 @@
+#
+# Helpers to facilitate talking to sensu api
+#
+require 'net/https'
+require 'json'
+
+module SensuAPIUtil
+  def api_request(host, method, path)
+    begin
+      settings
+    rescue
+      raise 'your class needs to include Sensu::Plugin::Utils'
+    end
+    raise 'api.json settings not found.' unless settings.has_key?('api')
+
+    open_timeout = settings['api'].fetch('open_timeout', 10),
+    read_timeout = settings['api'].fetch('read_timeout', 10)
+    Net::HTTP.start(host, settings['api']['port'],
+                    :read_timeout => read_timeout) do |http|
+      http.open_timeout = open_timeout
+      req = Net::HTTP.const_get(method).new(path)
+      if settings['api']['user'] && settings['api']['password']
+        req.basic_auth(settings['api']['user'], settings['api']['password'])
+      end
+      req = yield(req) if block_given?
+      http.request(req)
+    end
+  end
+
+  def json_parse_api_request(host, method, path)
+    JSON.parse(api_request(host, method, path).body)
+  end
+end

--- a/manifests/server_side/install.pp
+++ b/manifests/server_side/install.pp
@@ -25,4 +25,11 @@ class monitoring_check::server_side::install (
     mode   => '0555',
     source => 'puppet:///modules/monitoring_check/check_remote_sensu.rb',
   }
+
+  file { '/etc/sensu/plugins/sensu_api_util.rb':
+    owner  => 'sensu',
+    group  => 'sensu',
+    mode   => '0444',
+    source => 'puppet:///modules/monitoring_check/sensu_api_util.rb',
+  }
 }


### PR DESCRIPTION
Improve code reuse by extracting some sensu api helper methods into their own module.