### PR TITLE
exit with unknown if failed to connect to redis

### DIFF
--- a/files/check-cluster.rb
+++ b/files/check-cluster.rb
@@ -167,7 +167,7 @@ private
       return yield
     else
       lock_key = "lock:#{config[:cluster_name]}:#{config[:check]}"
-      mutex = TinyRedis::Mutex.new(redis, lock_key, interval, logger)
+      mutex = TinyRedis::Mutex.new(redis, lock_key, interval, logger) rescue unknown('Failed to connect to redis')
       mutex.run_with_lock_or_skip do
         return yield
       end

--- a/files/check_server_side.rb
+++ b/files/check_server_side.rb
@@ -66,8 +66,9 @@ class CheckServerSide < Sensu::Plugin::Check::CLI
   def redis
     # settings will include redis server information on sensu servers but
     # not on sensu clients
-    @redis ||= TinyRedis::Client.new(host=settings['redis']['host'],
-                                     port=settings['redis']['port'])
+    @redis ||= TinyRedis::Client.new(
+      host=settings['redis']['host'],
+      port=settings['redis']['port']) rescue unknown('Failed to connect to redis')
   end
 
   def distributed_mutex

--- a/files/fleet_check.rb
+++ b/files/fleet_check.rb
@@ -172,8 +172,9 @@ class SensuFleetCheck < Sensu::Plugin::Check::CLI
   end
 
   def redis
-    @redis ||= TinyRedis::Client.new(host=settings['redis']['host'],
-                                     port=settings['redis']['port'])
+    @redis ||= TinyRedis::Client.new(
+      host=settings['redis']['host'],
+      port=settings['redis']['port']) rescue unknown('Failed to connect to redis')
   end
 
   def redis_key

--- a/spec/unit/check_cluster_spec.rb
+++ b/spec/unit/check_cluster_spec.rb
@@ -107,7 +107,9 @@ describe CheckCluster do
     context "should be UNKNOWN" do
       it "when SocketError happens" do
         expect(TinyRedis::Mutex).to receive(:new).and_raise SocketError
-        expect_status :unknown, /127.0.0.1:7777: SocketError$/
+        expect(nil).to receive(:run_with_lock_or_skip).and_return(true)
+        expect(nil).to receive(:ttl).and_return(1)
+        expect_status :unknown, /^Failed to connect to redis$/
         check.run
       end
 

--- a/spec/unit_helper.rb
+++ b/spec/unit_helper.rb
@@ -17,6 +17,7 @@ module Sensu
     class Check
       class CLI
         def self.method_missing(*args); end
+        def method_missing(*args); end
       end
     end
 


### PR DESCRIPTION
My goal here is to avoid notifications (tickets or pages) when we couldn't connect to redis. Almost always it's a temporary issue with network or redis, and when it's not, we know about it through redis checks.

I think all these places have ```unknown``` method because they are within classes that inherit from ```Sensu::Plugin::Check::CLI```.