### PR TITLE
invert doc string

### DIFF
--- a/files/check-cluster.rb
+++ b/files/check-cluster.rb
@@ -69,7 +69,7 @@ class CheckCluster < Sensu::Plugin::Check::CLI
   option :silenced,
     :short => "-S yes",
     :long => "--silenced yes",
-    :description => "Include silenced hosts in total",
+    :description => "Exclude silenced hosts from total",
     :default => false
 
   option :ignore_nohosts,


### PR DESCRIPTION
@solarkennedy @keymone - it looks like https://github.com/Yelp/puppet-monitoring_check/blob/master/files/check-cluster.rb#L249 excludes silenced hosts from total, not includes them in it.

Requesting more pairs of eyes.