### PR TITLE
If ignore_nohosts is set to false, return critical if no hosts are re…

### DIFF
--- a/files/check-cluster.rb
+++ b/files/check-cluster.rb
@@ -244,6 +244,9 @@ private
   #             target check silenced
   def check_aggregate(summary)
     total, ok, silenced, stale, failing = summary.values_at(:total, :ok, :silenced, :stale, :failing)
+
+    return :critical, 'No servers running the check, ignore_hohosts set to false' if !config[:ignore_nohosts]
+
     return 'OK', 'No servers running the check' if total.zero?
 
     eff_total = total - silenced * (config[:silenced] ? 1 : 0)

--- a/files/check-cluster.rb
+++ b/files/check-cluster.rb
@@ -245,12 +245,17 @@ private
   def check_aggregate(summary)
     total, ok, silenced, stale, failing = summary.values_at(:total, :ok, :silenced, :stale, :failing)
 
-    return :critical, 'No servers running the check, ignore_hohosts set to false' if !config[:ignore_nohosts]
-
-    return 'OK', 'No servers running the check' if total.zero?
-
     eff_total = total - silenced * (config[:silenced] ? 1 : 0)
-    return 'OK', 'All hosts silenced' if eff_total.zero?
+
+    if total.zero?
+      if !config[:ignore_nohosts]
+        return 'CRITICAL', 'No servers running the check, ignore_hohosts set to false'
+      else
+        return 'OK', 'No servers running the check'
+      end
+    elsif eff_total.zero?
+      return 'OK', 'All hosts silenced' if eff_total.zero?
+    end
 
     ok_pct  = (100 * ok / eff_total.to_f).to_i
 

--- a/files/check-cluster.rb
+++ b/files/check-cluster.rb
@@ -78,6 +78,13 @@ class CheckCluster < Sensu::Plugin::Check::CLI
     :description => "Don't fail if there are no hosts",
     :default => false
 
+  option :critical_when_nohosts,
+    :short => "-r",
+    :long => "--critical-when-nohosts",
+    :boolean => true,
+    :description => "If no hosts report individual checks, return CRITICAL.",
+    :default => false
+
   option :dryrun,
     :short => "-d",
     :long => "--dry-run",
@@ -248,13 +255,13 @@ private
     eff_total = total - silenced * (config[:silenced] ? 1 : 0)
 
     if total.zero?
-      if !config[:ignore_nohosts]
-        return 'CRITICAL', 'No servers running the check, ignore_hohosts set to false'
+      if config[:critical_when_nohosts]
+        return 'CRITICAL', 'No servers running the check, and --critical-when-nohosts has been set'
       else
         return 'OK', 'No servers running the check'
       end
     elsif eff_total.zero?
-      return 'OK', 'All hosts silenced' if eff_total.zero?
+      return 'OK', 'All hosts silenced'
     end
 
     ok_pct  = (100 * ok / eff_total.to_f).to_i


### PR DESCRIPTION
…porting individual checks

A very tentative PR here. I noticed we already have a config setting `ignore_nohosts`, which seems very similar to the proposed option we discussed that would alert critical if there are no hosts reporting individual checks.

I'm not very sure on the current usage of this parameter though. The fact that its false by default means that this PR might change the current behavior of some monitoring checks.